### PR TITLE
Add continuous tape support for D-series printers

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -80,6 +80,7 @@ import {
   M_SERIES_LABEL_SIZES,
   M_SERIES_ROUND_LABELS,
   D_SERIES_LABEL_SIZES,
+  D_SERIES_CONTINUOUS_SIZES,
   D_SERIES_ROUND_LABELS,
   TAPE_LABEL_SIZES,
   PM241_LABEL_SIZES,
@@ -783,7 +784,7 @@ function updateLabelSizeDropdown(deviceName = '', model = 'auto') {
     roundSizes = {}; // No round labels for tape printers
     defaultKey = `40x${state.tapeWidth}`;
   } else if (isDSeries) {
-    // D-series uses fixed narrow label sizes
+    // D-series uses fixed narrow label sizes + continuous tape options
     rectSizes = D_SERIES_LABEL_SIZES;
     roundSizes = D_SERIES_ROUND_LABELS;
     defaultKey = '40x12';
@@ -799,7 +800,8 @@ function updateLabelSizeDropdown(deviceName = '', model = 'auto') {
     defaultKey = '40x30';
   }
 
-  LABEL_SIZES = { ...rectSizes, ...roundSizes };
+  const continuousSizes = isDSeries ? D_SERIES_CONTINUOUS_SIZES : {};
+  LABEL_SIZES = { ...rectSizes, ...roundSizes, ...continuousSizes };
 
   // Clear existing options (except custom)
   while (select.options.length > 0) {
@@ -825,6 +827,21 @@ function updateLabelSizeDropdown(deviceName = '', model = 'auto') {
       const option = document.createElement('option');
       option.value = key;
       option.textContent = key; // e.g., "20mm Round"
+      select.appendChild(option);
+    }
+  }
+
+  // Add continuous tape options for D-series
+  if (Object.keys(continuousSizes).length > 0) {
+    const separator = document.createElement('option');
+    separator.disabled = true;
+    separator.textContent = '── Continuous Tape ──';
+    select.appendChild(separator);
+
+    for (const [key, size] of Object.entries(continuousSizes)) {
+      const option = document.createElement('option');
+      option.value = key;
+      option.textContent = `${size.width}x${size.height}mm (cont.)`;
       select.appendChild(option);
     }
   }
@@ -904,6 +921,8 @@ function updateMobileLabelSizeDropdown(deviceName = '', model = 'auto') {
     roundSizes = M_SERIES_ROUND_LABELS;
   }
 
+  const continuousSizes = isDSeries ? D_SERIES_CONTINUOUS_SIZES : {};
+
   // Clear and rebuild mobile dropdown
   while (mobileSelect.options.length > 0) {
     mobileSelect.remove(0);
@@ -932,6 +951,21 @@ function updateMobileLabelSizeDropdown(deviceName = '', model = 'auto') {
     }
   }
 
+  // Add continuous tape options for D-series
+  if (Object.keys(continuousSizes).length > 0) {
+    const separator = document.createElement('option');
+    separator.disabled = true;
+    separator.textContent = '── Continuous ──';
+    mobileSelect.appendChild(separator);
+
+    for (const [key, size] of Object.entries(continuousSizes)) {
+      const option = document.createElement('option');
+      option.value = key;
+      option.textContent = `${size.width}x${size.height}mm (cont.)`;
+      mobileSelect.appendChild(option);
+    }
+  }
+
   // Add custom option
   const customOption = document.createElement('option');
   customOption.value = 'custom';
@@ -950,12 +984,15 @@ function updateMobileLabelSizeDropdown(deviceName = '', model = 'auto') {
 
 /**
  * Check if the currently connected printer is a continuous tape printer (P12/A30)
- * @returns {boolean} True if tape printer is connected
+ * or a D-series with a continuous tape label selected
+ * @returns {boolean} True if continuous tape mode is active
  */
 function isContinuousTapePrinter() {
   const deviceName = state.transport?.getDeviceName?.() || '';
   const printerModel = state.printSettings.printerModel;
-  return isTapePrinter(deviceName, printerModel);
+  if (isTapePrinter(deviceName, printerModel)) return true;
+  // D-series with continuous label selected
+  return !!(state.labelSize && state.labelSize.continuous);
 }
 
 /**
@@ -1037,23 +1074,24 @@ function loadTapeWidthForDevice(deviceName) {
 }
 
 /**
- * Adjust the label length by a delta (for P12 continuous tape)
+ * Adjust the label length by a delta (for continuous tape printers)
  * @param {number} delta - Amount to adjust in mm (positive or negative)
  */
 function adjustLabelLength(delta) {
   const currentWidth = state.labelSize.width;
+  const tapeHeight = state.labelSize.height || 12;
   const newWidth = Math.max(10, Math.min(100, currentWidth + delta));
 
   if (newWidth !== currentWidth) {
-    // Update to custom size
-    state.labelSize = { width: newWidth, height: 12 };
+    // Update to custom size, preserve continuous flag and tape height
+    state.labelSize = { width: newWidth, height: tapeHeight, continuous: state.labelSize.continuous || false };
     $('#label-size').value = 'custom';
     $('#custom-size').classList.remove('hidden');
     $('#custom-width').value = newWidth;
-    $('#custom-height').value = 12;
+    $('#custom-height').value = tapeHeight;
 
     // Update canvas
-    state.renderer.setDimensions(newWidth, 12, state.zoom, false);
+    state.renderer.setDimensions(newWidth, tapeHeight, state.zoom, false);
     state.renderer.clearCache();
     render();
     updatePrintSize();
@@ -1062,7 +1100,7 @@ function adjustLabelLength(delta) {
     $('#mobile-label-size').value = 'custom';
     $('#mobile-custom-size')?.classList.remove('hidden');
     $('#mobile-custom-width').value = newWidth;
-    $('#mobile-custom-height').value = 12;
+    $('#mobile-custom-height').value = tapeHeight;
   }
 }
 
@@ -1903,6 +1941,7 @@ async function handleBatchPrint() {
         printerModel,
         density,
         feed,
+        continuous: !!(state.labelSize?.continuous),
         onProgress: (progress) => {
           updatePrintProgress(rowIndex + 1, totalRows, `Sending data... ${progress}%`);
         },
@@ -1989,6 +2028,7 @@ async function handlePrintSinglePreview() {
       printerModel,
       density,
       feed,
+      continuous: !!(state.labelSize?.continuous),
       onProgress: (progress) => {
         btn.textContent = `Printing... ${progress}%`;
       },
@@ -2400,6 +2440,7 @@ function handleLabelSizeChange() {
 
   state.renderer.setDimensions(state.labelSize.width, state.labelSize.height, state.zoom, state.labelSize.round || false);
   updatePrintSize();
+  updateLengthAdjustButtons();
 
   // Auto zoom-to-fit if label is too large at 100% zoom
   zoomToFitIfNeeded();
@@ -4728,6 +4769,7 @@ async function handlePrint() {
         printerModel,
         density,
         feed,
+        continuous: !!(state.labelSize?.continuous),
         onProgress: (progress) => {
           btn.textContent = `Printing... ${progress}%`;
           setStatus(`Printing${copyText}... ${progress}%`);

--- a/src/web/constants.js
+++ b/src/web/constants.js
@@ -180,6 +180,15 @@ export const D_SERIES_LABEL_SIZES = {
   '30x15': { width: 30, height: 15 },
 };
 
+// D-series continuous tape sizes (no die-cut gaps)
+export const D_SERIES_CONTINUOUS_SIZES = {
+  '40x12 cont': { width: 40, height: 12, continuous: true },
+  '30x12 cont': { width: 30, height: 12, continuous: true },
+  '22x12 cont': { width: 22, height: 12, continuous: true },
+  '40x15 cont': { width: 40, height: 15, continuous: true },
+  '30x15 cont': { width: 30, height: 15, continuous: true },
+};
+
 // Round/circle labels for D-series printers - diameter in mm
 export const D_SERIES_ROUND_LABELS = {
   '14mm Round': { width: 14, height: 14, round: true },

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1290,6 +1290,7 @@
         <div>
           <div class="prop-label">Feed After Print</div>
           <select id="print-feed" class="prop-input">
+            <option value="0">None (no gap)</option>
             <option value="16">Small (2mm)</option>
             <option value="32" selected>Medium (4mm)</option>
             <option value="48">Large (6mm)</option>

--- a/src/web/printer.js
+++ b/src/web/printer.js
@@ -282,7 +282,8 @@ const D_CMD = {
     rows % 256,
     Math.floor(rows / 256),
   ]),
-  END: new Uint8Array([0x1b, 0x64, 0x00]),
+  END: new Uint8Array([0x1b, 0x64, 0x00]),  // ESC d 0 - print, no feed (gap detection for die-cut)
+  FEED: (dots) => new Uint8Array([0x1b, 0x4a, dots & 0xff]),  // ESC J n - feed n dots (for continuous tape)
 };
 
 // M110-series specific commands (based on phomemo-tools project)
@@ -612,7 +613,7 @@ function rotateRaster90CCW(data, widthBytes, heightLines) {
  * @param {Function} options.onProgress - Progress callback (percent)
  */
 export async function print(transport, rasterData, options = {}) {
-  const { isBLE = false, deviceName = '', printerModel = 'auto', density = 6, feed = 32, onProgress = null } = options;
+  const { isBLE = false, deviceName = '', printerModel = 'auto', density = 6, feed = 32, continuous = false, onProgress = null } = options;
   const { data, widthBytes, heightLines } = rasterData;
 
   const isDSeries = isDSeriesPrinter(deviceName, printerModel);
@@ -637,7 +638,7 @@ export async function print(transport, rasterData, options = {}) {
     await printP12(transport, data, widthBytes, heightLines, onProgress);
   } else if (isDSeries && isBLE) {
     // D-series (D30, D110, etc.)
-    await printDSeries(transport, data, widthBytes, heightLines, onProgress, density);
+    await printDSeries(transport, data, widthBytes, heightLines, onProgress, density, continuous, feed);
   } else if (isM02 && isBLE) {
     await printM02(transport, data, widthBytes, heightLines, density, onProgress);
   } else if (isM04 && isBLE) {
@@ -656,7 +657,7 @@ export async function print(transport, rasterData, options = {}) {
  * Print via BLE for D-series printers (D30, D110, etc.)
  * Uses rotated printing with D-series protocol
  */
-async function printDSeries(transport, data, widthBytes, heightLines, onProgress, density = 6) {
+async function printDSeries(transport, data, widthBytes, heightLines, onProgress, density = 6, continuous = false, feed = 0) {
   console.log('Using D-series protocol...');
   console.log(`Input: ${widthBytes} bytes wide x ${heightLines} rows (${data.length} bytes)`);
 
@@ -664,32 +665,57 @@ async function printDSeries(transport, data, widthBytes, heightLines, onProgress
   const rotated = rotateRaster90CW(data, widthBytes, heightLines);
   console.log(`Rotated: ${rotated.widthBytes} bytes wide x ${rotated.heightLines} rows`);
 
+  // For continuous tape, pad raster with blank rows to push content past the cutter
+  // ESC J feed is ignored in continuous mode, so we bake the feed into the image data
+  let printData = rotated.data;
+  let printRows = rotated.heightLines;
+  if (continuous && feed > 0) {
+    // The D30 has ~7mm (56 dots) from print head to cutter edge - content needs this
+    // padding just to reach the cut point, then 'feed' adds extra margin beyond that
+    const cutterOffset = 56; // ~7mm head-to-cutter distance at 203 DPI
+    const paddingRows = cutterOffset + feed;
+    const paddingBytes = paddingRows * rotated.widthBytes;
+    const padded = new Uint8Array(rotated.data.length + paddingBytes);
+    padded.set(rotated.data);
+    // Rest is already zeros (blank rows)
+    printData = padded;
+    printRows = rotated.heightLines + paddingRows;
+    console.log(`Continuous tape: added ${paddingRows} blank rows (${cutterOffset} cutter offset + ${feed} feed, ${printRows} total rows)`);
+  }
+
   // Set heat/density before header
   const heatTime = densityToHeatTime(density);
   console.log(`Setting density ${density} (heat time: ${heatTime})...`);
   await transport.send(CMD.HEAT_SETTINGS(7, heatTime, 2));
   await transport.delay(30);
 
+  // For continuous tape, set media type to continuous (0x0B) to disable gap detection
+  if (continuous) {
+    console.log('Setting media type to continuous (1F 11 0B)...');
+    await transport.send(new Uint8Array([0x1f, 0x11, 0x0b]));
+    await transport.delay(30);
+  }
+
   // Send D-series header (includes ESC @ init)
   console.log('Sending D-series header...');
-  await transport.send(D_CMD.HEADER(rotated.widthBytes, rotated.heightLines));
+  await transport.send(D_CMD.HEADER(rotated.widthBytes, printRows));
 
   // Send data in chunks
   console.log('Sending data...');
   const chunkSize = 128;
 
-  for (let i = 0; i < rotated.data.length; i += chunkSize) {
-    const chunk = rotated.data.slice(i, Math.min(i + chunkSize, rotated.data.length));
+  for (let i = 0; i < printData.length; i += chunkSize) {
+    const chunk = printData.slice(i, Math.min(i + chunkSize, printData.length));
     await transport.send(chunk);
     await transport.delay(20);
 
     if (onProgress) {
-      const progress = Math.round((i + chunk.length) / rotated.data.length * 100);
+      const progress = Math.round((i + chunk.length) / printData.length * 100);
       onProgress(progress);
     }
   }
 
-  // D-series end command
+  // D-series end command (ESC d 0 - gap detection for die-cut, no-op for continuous)
   await transport.delay(100);
   console.log('Sending D-series end command...');
   await transport.send(D_CMD.END);

--- a/src/web/printer.js
+++ b/src/web/printer.js
@@ -689,12 +689,11 @@ async function printDSeries(transport, data, widthBytes, heightLines, onProgress
   await transport.send(CMD.HEAT_SETTINGS(7, heatTime, 2));
   await transport.delay(30);
 
-  // For continuous tape, set media type to continuous (0x0B) to disable gap detection
-  if (continuous) {
-    console.log('Setting media type to continuous (1F 11 0B)...');
-    await transport.send(new Uint8Array([0x1f, 0x11, 0x0b]));
-    await transport.delay(30);
-  }
+  // Set media type: continuous (0x0B) disables gap detection, gaps (0x0A) enables it
+  const mediaType = continuous ? 0x0b : 0x0a;
+  console.log(`Setting media type to ${continuous ? 'continuous' : 'gaps'} (1F 11 ${mediaType.toString(16).padStart(2, '0')})...`);
+  await transport.send(new Uint8Array([0x1f, 0x11, mediaType]));
+  await transport.delay(30);
 
   // Send D-series header (includes ESC @ init)
   console.log('Sending D-series header...');


### PR DESCRIPTION
## Summary

- Adds continuous tape label presets to the D-series label size dropdown (12mm widths)
- Sends Phomemo proprietary command `1F 11 0B` to set media type to continuous, disabling gap detection that caused endless feeding
- Explicitly resets to `1F 11 0A` (gaps) for die-cut labels so mode doesn't persist
- Pads raster data with blank rows to account for the ~7mm print head-to-cutter offset
- "Feed After Print" controls extra margin beyond the cutter; "None (no gap)" option enables back-to-back printing
- Shows +/- length adjust buttons when continuous labels are selected

## Background

D-series printers (D30, D35, etc.) with continuous tape would feed endlessly after printing because the firmware's gap detection never found a label gap to stop at. The fix sends `1F 11 0B` before printing to switch the printer to continuous media mode (and `1F 11 0A` to switch to gap detection for non-continuous labels). Since ESC/POS feed commands are ignored in this mode, the feed margin is baked into the raster data as blank padding rows.

## Test plan

- [x] Tested on real D30 hardware with 12mm continuous tape (actually 15mm tape, but tested with 12mm settings)
- [x] Verified die-cut labels still work normally after switching back from continuous
- [x] Verified "Feed After Print" settings (None, Small, Medium, Large) produce correct margins
- [x] Verified +/- length adjust buttons appear for continuous presets
- [x] `npm run test` all pass
- [ ] Test on D35/D50/Q30 if available (I don't have one)

## Notes

- FYI I did this with an agent co-author, so it might be a bit verbose but it works well. 
- I only have a D30 so that's all I tested on
- The print head is only 12mm, and none of the 15mm stuff is working, but I think that's a separate issue (#26)
- There is a small behaviour change added that might impact other printers - the "None (no gap)" print feed is meant to allow printing a bunch of labels in a row, where they will be manually cut after. It does not feed enough for the label to clear the cutter. 
- Feel free to cherry-pick parts of this or refactor it into a new PR or whatever. I did _not_ pay close attention to coding styles and conventions. But I'm also ok to rework it to match if requested!
- Oh maybe we  should also update this comment `// 1F 11 0B - Init command (required, purpose undetermined)` - purpose is to set media mode!
- I did not add new test(s). Maybe we should?