### PR TITLE
[codex] Add Windows Python wrapper for Playwright server

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'python3 -m http.server 8081 --directory src/web',
+    command: 'node scripts/python3.cjs -m http.server 8081 --directory src/web',
     port: 8081,
     reuseExistingServer: !process.env.CI,
     timeout: 10_000,

--- a/scripts/python3.cjs
+++ b/scripts/python3.cjs
@@ -1,0 +1,17 @@
+const { spawn } = require('node:child_process');
+
+// Windows development wrapper: this project expects `python3`, while Windows commonly exposes Python 3 through the `py -3` launcher.
+const isWindows = process.platform === 'win32';
+const command = isWindows ? 'py' : 'python3';
+const args = isWindows ? ['-3', ...process.argv.slice(2)] : process.argv.slice(2);
+
+const child = spawn(command, args, { stdio: 'inherit' });
+
+child.on('error', (error) => {
+  console.error(`Failed to start ${command}: ${error.message}`);
+  process.exit(1);
+});
+
+child.on('exit', (code) => {
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Summary
- Add a project-local Python wrapper for Playwright's web server command.
- Keep the existing `python3` behavior on Linux/macOS.
- Use the Windows `py -3` launcher when tests run on Windows.

## Why
The Playwright config starts the local test server with `python3`, but Windows commonly exposes Python 3 through the `py -3` launcher instead. This keeps the app code unchanged and limits the Windows-specific logic to a small wrapper.

## Validation
- `node scripts/python3.cjs --version`
- `npm test` - 27 passed